### PR TITLE
Take in account RDF content inside named graphs

### DIFF
--- a/js/outils.js
+++ b/js/outils.js
@@ -277,11 +277,13 @@ function rechercheFromParam(paramSujet,paramPropriete,paramObjet){
    if( typeof paramRequete == "undefined"){
    //queryAsk = "SELECT * WHERE { <"+paramSujet+"> "+paramPropriete+" "+paramObjet+" } LIMIT 100 ";
    queryAsk  = "SELECT DISTINCT * WHERE { \n";
-   queryAsk += "<"+paramSujet+"> "+paramPropriete+" "+paramObjet+" . \n";
-   queryAsk += "OPTIONAL { ?Objet ?p2 ?o2 } . \n";
-   queryAsk += "OPTIONAL { ?s3 ?p3 <"+paramSujet+"> }. \n";
 
-   queryAsk += " } ";
+   var wherePart = "<"+paramSujet+"> "+paramPropriete+" "+paramObjet+" . \n";
+   wherePart += "OPTIONAL { ?Objet ?p2 ?o2 } . \n";
+   wherePart += "OPTIONAL { ?s3 ?p3 <"+paramSujet+"> }. \n";
+   var wherePartComplete = "OPTIONAL { " + wherePart + "} GRAPH ?GRAPH { " + wherePart + " }";
+
+   queryAsk += wherePartComplete + " } ";
    queryAsk += "LIMIT 200 ";
 
   }else{


### PR DESCRIPTION
TESTED with server semantic_forms:
file:///home/jmv/src/graphe/index.html?endpoint=http://localhost:9000/sparql&sujet=http://jmvanel.free.fr/jmv.rdf
=> Json-LD triples arrive BUT graph empty !
Maybe the ?GRAPH variable is a problem ???

TESTED with server fr.dbpedia.org:
file:///home/jmv/src/graphe/index.html?endpoint=http://fr.dbpedia.org/sparql&sujet=http://fr.dbpedia.org/resource/Resource_Description_Framework
=> graph looks good!